### PR TITLE
Use spans instead of markers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,5 +40,5 @@ mod parser;
 mod scanner;
 
 pub use crate::input::BufferedInput;
-pub use crate::parser::{Event, EventReceiver, MarkedEventReceiver, Parser, Tag};
-pub use crate::scanner::{Marker, ScanError, TScalarStyle};
+pub use crate::parser::{Event, EventReceiver, Parser, SpannedEventReceiver, Tag};
+pub use crate::scanner::{Marker, ScanError, Span, TScalarStyle};

--- a/tests/span.rs
+++ b/tests/span.rs
@@ -1,0 +1,136 @@
+#![allow(clippy::bool_assert_comparison)]
+#![allow(clippy::float_cmp)]
+
+use saphyr_parser::{Event, Parser, ScanError};
+
+/// Run the parser through the string, returning all the scalars, and collecting their spans to strings.
+fn run_parser_and_deref_scalar_spans(input: &str) -> Result<Vec<(String, String)>, ScanError> {
+    let mut events = vec![];
+    for x in Parser::new_from_str(input) {
+        let x = x?;
+        if let Event::Scalar(s, ..) = x.0 {
+            let start = x.1.start.index();
+            let end = x.1.end.index();
+            let input_s = input.chars().skip(start).take(end - start).collect();
+            events.push((s, input_s));
+        }
+    }
+    Ok(events)
+}
+
+/// Run the parser through the string, returning all the scalars, and collecting their spans to strings.
+fn run_parser_and_deref_seq_spans(input: &str) -> Result<Vec<String>, ScanError> {
+    let mut events = vec![];
+    let mut start_stack = vec![];
+    for x in Parser::new_from_str(input) {
+        let x = x?;
+        match x.0 {
+            Event::SequenceStart(_, _) => start_stack.push(x.1.start.index()),
+            Event::SequenceEnd => {
+                let start = start_stack.pop().unwrap();
+                let end = x.1.end.index();
+                let input_s = input.chars().skip(start).take(end - start).collect();
+                events.push(input_s);
+            }
+            _ => {}
+        }
+    }
+    Ok(events)
+}
+
+fn deref_pairs(pairs: &[(String, String)]) -> Vec<(&str, &str)> {
+    pairs
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect()
+}
+
+#[test]
+fn test_plain() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: bar").unwrap()),
+        [("foo", "foo"), ("bar", "bar"),]
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: bar ").unwrap()),
+        [("foo", "foo"), ("bar", "bar"),]
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo :  \t  bar\t ").unwrap()),
+        [("foo", "foo"), ("bar", "bar"),]
+    );
+
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo :  \n  - bar\n  - baz\n ").unwrap()),
+        [("foo", "foo"), ("bar", "bar"), ("baz", "baz")]
+    );
+}
+
+#[test]
+fn test_plain_utf8() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("a: 你好").unwrap()),
+        [("a", "a"), ("你好", "你好")]
+    );
+}
+
+#[test]
+fn test_quoted() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans(r#"foo: "bar""#).unwrap()),
+        [("foo", "foo"), ("bar", r#""bar""#),]
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans(r#"foo: 'bar'"#).unwrap()),
+        [("foo", "foo"), ("bar", r#"'bar'"#),]
+    );
+
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans(r#"foo: "bar ""#).unwrap()),
+        [("foo", "foo"), ("bar ", r#""bar ""#),]
+    );
+}
+
+#[test]
+fn test_literal() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: |\n  bar").unwrap()),
+        [("foo", "foo"), ("bar\n", "bar"),]
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: |\n  bar\n  more").unwrap()),
+        [("foo", "foo"), ("bar\nmore\n", "bar\n  more"),]
+    );
+}
+
+#[test]
+fn test_block() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: >\n  bar").unwrap()),
+        [("foo", "foo"), ("bar\n", "bar"),]
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: >\n  bar\n  more").unwrap()),
+        [("foo", "foo"), ("bar more\n", "bar\n  more"),]
+    );
+}
+
+#[test]
+fn test_seq() {
+    assert_eq!(
+        run_parser_and_deref_seq_spans("[a, b]").unwrap(),
+        ["[a, b]"]
+    );
+    assert_eq!(
+        run_parser_and_deref_seq_spans("- a\n- b").unwrap(),
+        ["- a\n- b"]
+    );
+    assert_eq!(
+        run_parser_and_deref_seq_spans("foo:\n  - a\n  - b").unwrap(),
+        ["- a\n  - b"]
+    );
+    assert_eq!(
+        run_parser_and_deref_seq_spans("foo:\n  - a\n  - bar:\n    - b\n    - c").unwrap(),
+        ["b\n    - c", "- a\n  - bar:\n    - b\n    - c"]
+    );
+}

--- a/tools/dump_events.rs
+++ b/tools/dump_events.rs
@@ -2,21 +2,21 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 
-use saphyr_parser::{Event, MarkedEventReceiver, Marker, Parser};
+use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 #[derive(Debug)]
 struct EventSink {
-    events: Vec<(Event, Marker)>,
+    events: Vec<(Event, Span)>,
 }
 
-impl MarkedEventReceiver for EventSink {
-    fn on_event(&mut self, ev: Event, mark: Marker) {
+impl SpannedEventReceiver for EventSink {
+    fn on_event(&mut self, ev: Event, span: Span) {
         eprintln!("      \x1B[;34m\u{21B3} {:?}\x1B[;m", &ev);
-        self.events.push((ev, mark));
+        self.events.push((ev, span));
     }
 }
 
-fn str_to_events(yaml: &str) -> Vec<(Event, Marker)> {
+fn str_to_events(yaml: &str) -> Vec<(Event, Span)> {
     let mut sink = EventSink { events: Vec::new() };
     let mut parser = Parser::new_from_str(yaml);
     // Load events using our sink as the receiver.

--- a/tools/run_bench.rs
+++ b/tools/run_bench.rs
@@ -1,15 +1,13 @@
 #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
 
-use saphyr_parser::{
-    Event, Marker, {MarkedEventReceiver, Parser},
-};
+use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
 use std::{env, fs::File, io::prelude::*};
 
 /// A sink which discards any event sent.
 struct NullSink {}
 
-impl MarkedEventReceiver for NullSink {
-    fn on_event(&mut self, _: Event, _: Marker) {}
+impl SpannedEventReceiver for NullSink {
+    fn on_event(&mut self, _: Event, _: Span) {}
 }
 
 /// Parse the given input, returning elapsed time in nanoseconds.

--- a/tools/time_parse.rs
+++ b/tools/time_parse.rs
@@ -2,13 +2,13 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 
-use saphyr_parser::{Event, MarkedEventReceiver, Marker, Parser};
+use saphyr_parser::{Event, Parser, Span, SpannedEventReceiver};
 
 /// A sink which discards any event sent.
 struct NullSink {}
 
-impl MarkedEventReceiver for NullSink {
-    fn on_event(&mut self, _: Event, _: Marker) {}
+impl SpannedEventReceiver for NullSink {
+    fn on_event(&mut self, _: Event, _: Span) {}
 }
 
 fn main() {


### PR DESCRIPTION
Hi! We've been trying to use saphyr's recent support for parsing-with-marks to give nice error messages with locations underlined and so on. But having only a single mark instead of a span (with a start and an end) turns out to be pretty tricky for the downstream user. This is especially true for scalars:

- the length of the scalar doesn't help find the end position, especially for folded blocks where the scalar value can be much shorter than the amount of space it takes in the input
- the starting position of the next event is a little better, but needs some processing to deal with whitespace (and also potentially separators like`-` or `:`).

So this PR adds span support to the scanner and changes `MarkedEventReceiver` to `SpannedEventReceiver`. It also adds some tests, although they should probably be more comprehensive -- I first wanted to get a sense of whether this is something you'd be interested in supporting.