### PR TITLE
Remove all unsafe code

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -45,16 +45,18 @@ pub trait Input {
 
     /// Read a character from the input stream and return it directly.
     ///
-    /// The internal buffer (is any) is bypassed.
+    /// The internal buffer (if any) is bypassed.
     #[must_use]
     fn raw_read_ch(&mut self) -> char;
 
-    /// Put a character back in the buffer.
+    /// Read a non-breakz a character from the input stream and return it directly.
     ///
-    /// This function is only called when we read one too many characters and the pushed back
-    /// character is exactly the last character that was read. This function will not be called
-    /// multiple times consecutively.
-    fn push_back(&mut self, c: char);
+    /// The internal buffer (if any) is bypassed.
+    ///
+    /// If the next character is a breakz, it is either not consumed or placed into the buffer (if
+    /// any).
+    #[must_use]
+    fn raw_read_non_breakz_ch(&mut self) -> Option<char>;
 
     /// Consume the next character.
     fn skip(&mut self);

--- a/src/input/buffered.rs
+++ b/src/input/buffered.rs
@@ -1,3 +1,4 @@
+use crate::char_traits::is_breakz;
 use crate::input::Input;
 
 use arraydeque::ArrayDeque;
@@ -68,8 +69,17 @@ impl<T: Iterator<Item = char>> Input for BufferedInput<T> {
     }
 
     #[inline]
-    fn push_back(&mut self, c: char) {
-        self.buffer.push_back(c).unwrap();
+    fn raw_read_non_breakz_ch(&mut self) -> Option<char> {
+        if let Some(c) = self.input.next() {
+            if is_breakz(c) {
+                self.buffer.push_back(c).unwrap();
+                None
+            } else {
+                Some(c)
+            }
+        } else {
+            None
+        }
     }
 
     #[inline]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1770,16 +1770,9 @@ impl<T: Input> Scanner<T> {
             // characters are appended here as their real size (1B for ascii, or up to 4 bytes for
             // UTF-8). We can then use the internal `line_buffer` `Vec` to push data into `string`
             // (using `String::push_str`).
-            let mut c = self.input.raw_read_ch();
-            while !is_breakz(c) {
+            while let Some(c) = self.input.raw_read_non_breakz_ch() {
                 line_buffer.push(c);
-                c = self.input.raw_read_ch();
             }
-
-            // Our last character read is stored in `c`. It is either an EOF or a break. In any
-            // case, we need to push it back into `self.buffer` so it may be properly read
-            // after. We must not insert it in `string`.
-            self.input.push_back(c);
 
             // We need to manually update our position; we haven't called a `skip` function.
             self.mark.col += line_buffer.len();


### PR DESCRIPTION
Removes all use of `unsafe` replacing it with alternative code that, in some cases, is simpler.

Fixes undefined behavior detected by [Miri](https://github.com/rust-lang/miri):

```
error: Undefined Behavior: trying to retag from <235878> for SharedReadOnly permission at alloc79172[0x0], but that tag does not exist in the borrow stack for this location
   --> /home/eduardosm/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/raw.rs:140:9
    |
140 |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         trying to retag from <235878> for SharedReadOnly permission at alloc79172[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of retag at alloc79172[0x0..0x3]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <235878> was created by a SharedReadOnly retag at offsets [0x1..0x3]
   --> src/input/str.rs:445:9
    |
445 |         s.as_ptr().wrapping_sub(n),
    |         ^^^^^^^^^^
    = note: BACKTRACE (of the first span) on thread `input::str::tes`:
    = note: inside `std::slice::from_raw_parts::<'_, u8>` at /home/eduardosm/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/raw.rs:140:9: 140:47
note: inside `input::str::extend_left`
   --> src/input/str.rs:444:35
    |
444 |       std::str::from_utf8_unchecked(std::slice::from_raw_parts(
    |  ___________________________________^
445 | |         s.as_ptr().wrapping_sub(n),
446 | |         s.len() + n,
447 | |     ))
    | |_____^
note: inside `input::str::put_back_in_str`
   --> src/input/str.rs:438:5
    |
438 |     extend_left(s, n_bytes)
    |     ^^^^^^^^^^^^^^^^^^^^^^^
note: inside `input::str::test::put_back_in_str_example`
   --> src/input/str.rs:492:27
    |
492 |         let s3 = unsafe { put_back_in_str(s2, 'f') }; // OK, 'f' is the character immediately preceding
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> src/input/str.rs:489:37
    |
488 |     #[test]
    |     ------- in this procedural macro expansion
489 |     pub fn put_back_in_str_example() {
    |                                     ^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
```

It think the UB is because a slice (`&str`) only has "permission" to access the range of memory it refers so, once it has been subsliced, it is illegal to extend it back.