### PR TITLE
Refactor the `Input` trait

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -4,8 +4,6 @@ pub mod str;
 #[allow(clippy::module_name_repetitions)]
 pub use buffered::BufferedInput;
 
-use crate::char_traits::{is_blank_or_breakz, is_flow};
-
 /// Interface for a source of characters.
 ///
 /// Hiding the input's implementation behind this trait allows mostly:
@@ -167,20 +165,5 @@ pub trait Input {
     fn next_2_are(&self, c1: char, c2: char) -> bool {
         assert!(self.buflen() >= 2);
         self.peek() == c1 && self.peek_nth(1) == c2
-    }
-
-    /// Check whether the next characters may be part of a plain scalar.
-    ///
-    /// This function assumes we are not given a blankz character.
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
-    fn next_can_be_plain_scalar(&self, in_flow: bool) -> bool {
-        let nc = self.peek_nth(1);
-        match self.peek() {
-            // indicators can end a plain scalar, see 7.3.3. Plain Style
-            ':' if is_blank_or_breakz(nc) || (in_flow && is_flow(nc)) => false,
-            c if in_flow && is_flow(c) => false,
-            _ => true,
-        }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -43,18 +43,14 @@ pub trait Input {
         self.buflen() == 0
     }
 
-    /// Read a character from the input stream and return it directly.
+    /// Reads characters into `out` until `f` returns `true` or the end of input is reached.
     ///
-    /// The internal buffer (is any) is bypassed.
-    #[must_use]
-    fn raw_read_ch(&mut self) -> char;
-
-    /// Put a character back in the buffer.
+    /// The character that caused `f` to return `true` is not consumed or placed into `out`.
     ///
-    /// This function is only called when we read one too many characters and the pushed back
-    /// character is exactly the last character that was read. This function will not be called
-    /// multiple times consecutively.
-    fn push_back(&mut self, c: char);
+    /// Returns the number of read characters.
+    fn read_until<F>(&mut self, out: &mut String, f: F) -> usize
+    where
+        F: FnMut(char) -> bool;
 
     /// Consume the next character.
     fn skip(&mut self);

--- a/src/input.rs
+++ b/src/input.rs
@@ -334,21 +334,4 @@ pub trait Input {
     fn next_is_alpha(&self) -> bool {
         is_alpha(self.peek())
     }
-
-    /// Fetch characters from the input while we encounter letters and store them in `out`.
-    ///
-    /// The characters are consumed from the input.
-    ///
-    /// # Return
-    /// Return the number of characters that were consumed. The number of characters returned can
-    /// be used to advance the index and column, since no end-of-line character will be consumed.
-    fn fetch_while_is_alpha(&mut self, out: &mut String) -> usize {
-        let mut n_chars = 0;
-        while is_alpha(self.look_ch()) {
-            n_chars += 1;
-            out.push(self.peek());
-            self.skip();
-        }
-        n_chars
-    }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,9 +4,7 @@ pub mod str;
 #[allow(clippy::module_name_repetitions)]
 pub use buffered::BufferedInput;
 
-use crate::char_traits::{
-    is_alpha, is_blank, is_blank_or_breakz, is_break, is_breakz, is_digit, is_flow, is_z,
-};
+use crate::char_traits::{is_blank_or_breakz, is_flow};
 
 /// Interface for a source of characters.
 ///
@@ -98,6 +96,25 @@ pub trait Input {
     #[must_use]
     fn peek(&self) -> char;
 
+    /// Return the next character, without consuming it.
+    ///
+    /// Users of the [`Input`] must make sure that the character has been loaded through a prior
+    /// call to [`Input::lookahead`]. Implementors of [`Input`] may assume that a valid call to
+    /// [`Input::lookahead`] has been made beforehand.
+    ///
+    /// # Return
+    ///
+    /// If the input source is not exhausted, returns the next character to be fed into the
+    /// scanner. Otherwise, returns `\0`.
+    ///
+    /// If the next character is not an ASCII character, the returned character is a non-ASCII
+    /// character that might not be the actual character found in the input (e.g., it might be
+    /// an UTF-8 byte casted to `char`).
+    #[must_use]
+    fn peek_ascii(&self) -> char {
+        self.peek()
+    }
+
     /// Return the `n`-th character in the buffer, without consuming it.
     ///
     /// This function assumes that the n-th character in the input has already been fetched through
@@ -114,16 +131,6 @@ pub trait Input {
     fn look_ch(&mut self) -> char {
         self.lookahead(1);
         self.peek()
-    }
-
-    /// Return whether the next character in the input source is equal to `c`.
-    ///
-    /// This function assumes that the next character in the input has already been fetched through
-    /// [`Input::lookahead`].
-    #[inline]
-    #[must_use]
-    fn next_char_is(&self, c: char) -> bool {
-        self.peek() == c
     }
 
     /// Return whether the `n`-th character in the input source is equal to `c`.
@@ -205,133 +212,5 @@ pub trait Input {
             c if in_flow && is_flow(c) => false,
             _ => true,
         }
-    }
-
-    /// Check whether the next character is [a blank] or [a break].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a blank] or [a break], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a blank]: is_blank
-    /// [a break]: is_break
-    #[inline]
-    fn next_is_blank_or_break(&self) -> bool {
-        is_blank(self.peek()) || is_break(self.peek())
-    }
-
-    /// Check whether the next character is [a blank] or [a breakz].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a blank] or [a break], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a blank]: is_blank
-    /// [a breakz]: is_breakz
-    #[inline]
-    fn next_is_blank_or_breakz(&self) -> bool {
-        is_blank(self.peek()) || is_breakz(self.peek())
-    }
-
-    /// Check whether the next character is [a blank].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a blank], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a blank]: is_blank
-    #[inline]
-    fn next_is_blank(&self) -> bool {
-        is_blank(self.peek())
-    }
-
-    /// Check whether the next character is [a break].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a break], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a break]: is_break
-    #[inline]
-    fn next_is_break(&self) -> bool {
-        is_break(self.peek())
-    }
-
-    /// Check whether the next character is [a breakz].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a breakz], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a breakz]: is_breakz
-    #[inline]
-    fn next_is_breakz(&self) -> bool {
-        is_breakz(self.peek())
-    }
-
-    /// Check whether the next character is [a z].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a z], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a z]: is_z
-    #[inline]
-    fn next_is_z(&self) -> bool {
-        is_z(self.peek())
-    }
-
-    /// Check whether the next character is [a flow].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a flow], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a flow]: is_flow
-    #[inline]
-    fn next_is_flow(&self) -> bool {
-        is_flow(self.peek())
-    }
-
-    /// Check whether the next character is [a digit].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a digit], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a digit]: is_digit
-    #[inline]
-    fn next_is_digit(&self) -> bool {
-        is_digit(self.peek())
-    }
-
-    /// Check whether the next character is [a letter].
-    ///
-    /// The character must have previously been fetched through [`lookahead`]
-    ///
-    /// # Return
-    /// Returns true if the character is [a letter], false otherwise.
-    ///
-    /// [`lookahead`]: Input::lookahead
-    /// [a letter]: is_alpha
-    #[inline]
-    fn next_is_alpha(&self) -> bool {
-        is_alpha(self.peek())
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -111,8 +111,23 @@ pub trait Input {
     /// character that might not be the actual character found in the input (e.g., it might be
     /// an UTF-8 byte casted to `char`).
     #[must_use]
+    #[inline]
     fn peek_ascii(&self) -> char {
         self.peek()
+    }
+
+    /// Return the `n`-th character in the buffer, without consuming it.
+    ///
+    /// This function assumes that the n-th character in the input has already been fetched through
+    /// [`Input::lookahead`] and all non-consumed characters before the `n`-th are ASCII.
+    ///
+    /// If the `n`-th character is not ASCII, the returned character is a non-ASCII character that
+    /// might not be the actual character found in the input (e.g., it might be an UTF-8 byte casted
+    /// to `char`).
+    #[must_use]
+    #[inline]
+    fn peek_nth_ascii(&self, n: usize) -> char {
+        self.peek_nth(n)
     }
 
     /// Return the `n`-th character in the buffer, without consuming it.
@@ -152,51 +167,6 @@ pub trait Input {
     fn next_2_are(&self, c1: char, c2: char) -> bool {
         assert!(self.buflen() >= 2);
         self.peek() == c1 && self.peek_nth(1) == c2
-    }
-
-    /// Return whether the next 3 characters in the input source match the given characters.
-    ///
-    /// This function assumes that the next 3 characters in the input have already been fetched
-    /// through [`Input::lookahead`].
-    #[inline]
-    #[must_use]
-    fn next_3_are(&self, c1: char, c2: char, c3: char) -> bool {
-        assert!(self.buflen() >= 3);
-        self.peek() == c1 && self.peek_nth(1) == c2 && self.peek_nth(2) == c3
-    }
-
-    /// Check whether the next characters correspond to a document indicator.
-    ///
-    /// This function assumes that the next 4 characters in the input has already been fetched
-    /// through [`Input::lookahead`].
-    #[inline]
-    #[must_use]
-    fn next_is_document_indicator(&self) -> bool {
-        assert!(self.buflen() >= 4);
-        is_blank_or_breakz(self.peek_nth(3))
-            && (self.next_3_are('.', '.', '.') || self.next_3_are('-', '-', '-'))
-    }
-
-    /// Check whether the next characters correspond to a start of document.
-    ///
-    /// This function assumes that the next 4 characters in the input has already been fetched
-    /// through [`Input::lookahead`].
-    #[inline]
-    #[must_use]
-    fn next_is_document_start(&self) -> bool {
-        assert!(self.buflen() >= 4);
-        self.next_3_are('-', '-', '-') && is_blank_or_breakz(self.peek_nth(3))
-    }
-
-    /// Check whether the next characters correspond to an end of document.
-    ///
-    /// This function assumes that the next 4 characters in the input has already been fetched
-    /// through [`Input::lookahead`].
-    #[inline]
-    #[must_use]
-    fn next_is_document_end(&self) -> bool {
-        assert!(self.buflen() >= 4);
-        self.next_3_are('.', '.', '.') && is_blank_or_breakz(self.peek_nth(3))
     }
 
     /// Check whether the next characters may be part of a plain scalar.

--- a/src/input.rs
+++ b/src/input.rs
@@ -56,8 +56,8 @@ pub trait Input {
     ///
     /// The character that caused `f` to return `true` is not skipped.
     ///
-    /// When `f` receives a non-ascii character, it must return `true`. The non-ascii might not be
-    /// the actual character found in the input (e.g., it might be an UTF-8 byte cast to `char`).
+    /// When `f` receives a non-ASCII character, it must return `true`. The non-ASCII might not be
+    /// the actual character found in the input (e.g., it might be an UTF-8 byte casted to `char`).
     ///
     /// Returns the number of skipped characters.
     fn skip_ascii_until<F>(&mut self, mut f: F) -> usize
@@ -333,43 +333,6 @@ pub trait Input {
     #[inline]
     fn next_is_alpha(&self) -> bool {
         is_alpha(self.peek())
-    }
-
-    /// Skip characters from the input until a [breakz] is found.
-    ///
-    /// The characters are consumed from the input.
-    ///
-    /// # Return
-    /// Return the number of characters that were consumed. The number of characters returned can
-    /// be used to advance the index and column, since no end-of-line character will be consumed.
-    ///
-    /// [breakz]: is_breakz
-    #[inline]
-    fn skip_while_non_breakz(&mut self) -> usize {
-        let mut count = 0;
-        while !is_breakz(self.look_ch()) {
-            count += 1;
-            self.skip();
-        }
-        count
-    }
-
-    /// Skip characters from the input while [blanks] are found.
-    ///
-    /// The characters are consumed from the input.
-    ///
-    /// # Return
-    /// Return the number of characters that were consumed. The number of characters returned can
-    /// be used to advance the index and column, since no end-of-line character will be consumed.
-    ///
-    /// [blanks]: is_blank
-    fn skip_while_blank(&mut self) -> usize {
-        let mut n_chars = 0;
-        while is_blank(self.look_ch()) {
-            n_chars += 1;
-            self.skip();
-        }
-        n_chars
     }
 
     /// Fetch characters from the input while we encounter letters and store them in `out`.

--- a/src/input/buffered.rs
+++ b/src/input/buffered.rs
@@ -1,3 +1,4 @@
+use crate::char_traits::is_breakz;
 use crate::input::Input;
 
 use arraydeque::ArrayDeque;
@@ -62,14 +63,34 @@ impl<T: Iterator<Item = char>> Input for BufferedInput<T> {
         BUFFER_LEN
     }
 
-    #[inline]
-    fn raw_read_ch(&mut self) -> char {
-        self.input.next().unwrap_or('\0')
-    }
+    fn read_until<F>(&mut self, out: &mut String, mut f: F) -> usize
+    where
+        F: FnMut(char) -> bool,
+    {
+        let mut char_count = 0;
 
-    #[inline]
-    fn push_back(&mut self, c: char) {
-        self.buffer.push_back(c).unwrap();
+        for &c in &self.buffer {
+            if f(c) {
+                break;
+            }
+            out.push(c);
+            char_count += 1;
+        }
+
+        self.buffer.drain(0..char_count);
+
+        if self.buffer.is_empty() {
+            for c in self.input.by_ref() {
+                if f(c) {
+                    self.buffer.push_back(c).unwrap();
+                    break;
+                }
+                out.push(c);
+                char_count += 1;
+            }
+        }
+
+        char_count
     }
 
     #[inline]

--- a/src/input/buffered.rs
+++ b/src/input/buffered.rs
@@ -1,4 +1,3 @@
-use crate::char_traits::is_breakz;
 use crate::input::Input;
 
 use arraydeque::ArrayDeque;
@@ -61,6 +60,34 @@ impl<T: Iterator<Item = char>> Input for BufferedInput<T> {
     #[inline]
     fn bufmaxlen(&self) -> usize {
         BUFFER_LEN
+    }
+
+    fn skip_until<F>(&mut self, mut f: F) -> usize
+    where
+        F: FnMut(char) -> bool,
+    {
+        let mut char_count = 0;
+
+        for &c in &self.buffer {
+            if f(c) {
+                break;
+            }
+            char_count += 1;
+        }
+
+        self.buffer.drain(0..char_count);
+
+        if self.buffer.is_empty() {
+            for c in self.input.by_ref() {
+                if f(c) {
+                    self.buffer.push_back(c).unwrap();
+                    break;
+                }
+                char_count += 1;
+            }
+        }
+
+        char_count
     }
 
     fn read_until<F>(&mut self, out: &mut String, mut f: F) -> usize

--- a/src/input/str.rs
+++ b/src/input/str.rs
@@ -291,34 +291,6 @@ impl<'a> Input for StrInput<'a> {
     fn next_is_alpha(&self) -> bool {
         !self.buffer.is_empty() && is_alpha(self.buffer.as_bytes()[0] as char)
     }
-
-    fn fetch_while_is_alpha(&mut self, out: &mut String) -> usize {
-        let mut not_alpha = None;
-
-        // Skip while we have alpha characters.
-        let mut chars = self.buffer.chars();
-        for c in chars.by_ref() {
-            if !is_alpha(c) {
-                not_alpha = Some(c);
-                break;
-            }
-        }
-
-        let remaining_string = if let Some(c) = not_alpha {
-            let n_bytes_read = chars.as_str().as_ptr() as usize - self.buffer.as_ptr() as usize;
-            let last_char_bytes = c.len_utf8();
-            &self.buffer[n_bytes_read - last_char_bytes..]
-        } else {
-            chars.as_str()
-        };
-
-        let n_bytes_to_append = remaining_string.as_ptr() as usize - self.buffer.as_ptr() as usize;
-        out.reserve(n_bytes_to_append);
-        out.push_str(&self.buffer[..n_bytes_to_append]);
-        self.buffer = remaining_string;
-
-        n_bytes_to_append
-    }
 }
 
 /// The buffer size we return to the scanner.

--- a/src/input/str.rs
+++ b/src/input/str.rs
@@ -292,45 +292,6 @@ impl<'a> Input for StrInput<'a> {
         !self.buffer.is_empty() && is_alpha(self.buffer.as_bytes()[0] as char)
     }
 
-    fn skip_while_non_breakz(&mut self) -> usize {
-        let mut found_breakz = false;
-        let mut count = 0;
-
-        // Skip over all non-breaks.
-        let mut chars = self.buffer.chars();
-        for c in chars.by_ref() {
-            if is_breakz(c) {
-                found_breakz = true;
-                break;
-            }
-            count += 1;
-        }
-
-        self.buffer = if found_breakz {
-            // If we read a breakz, we need to put it back to the buffer.
-            // SAFETY: The last character we extracted is either a '\n', '\r' or '\0', all of which
-            // are 1-byte long.
-            unsafe { extend_left(chars.as_str(), 1) }
-        } else {
-            chars.as_str()
-        };
-
-        count
-    }
-
-    fn skip_while_blank(&mut self) -> usize {
-        // Since all characters we look for are ascii, we can directly use the byte API of str.
-        let mut i = 0;
-        while i < self.buffer.len() {
-            if !is_blank(self.buffer.as_bytes()[i] as char) {
-                break;
-            }
-            i += 1;
-        }
-        self.buffer = &self.buffer[i..];
-        i
-    }
-
     fn fetch_while_is_alpha(&mut self, out: &mut String) -> usize {
         let mut not_alpha = None;
 
@@ -383,15 +344,6 @@ impl<'a> Input for StrInput<'a> {
 /// [`bufmaxlen`]: `StrInput::bufmaxlen`
 /// [`buflen`]: `StrInput::buflen`
 const BUFFER_LEN: usize = 128;
-
-/// Extend the string by moving the start pointer to the left by `n` bytes.
-#[inline]
-unsafe fn extend_left(s: &str, n: usize) -> &str {
-    std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-        s.as_ptr().wrapping_sub(n),
-        s.len() + n,
-    ))
-}
 
 /// Splits the first character of the given string and returns it along with the rest of the
 /// string.

--- a/src/input/str.rs
+++ b/src/input/str.rs
@@ -1,7 +1,4 @@
-use crate::{
-    char_traits::{is_blank_or_breakz, is_flow},
-    input::Input,
-};
+use crate::input::Input;
 
 #[allow(clippy::module_name_repetitions)]
 pub struct StrInput<'a> {
@@ -172,28 +169,6 @@ impl<'a> Input for StrInput<'a> {
     fn next_2_are(&self, c1: char, c2: char) -> bool {
         let mut chars = self.buffer.chars();
         chars.next().is_some_and(|c| c == c1) && chars.next().is_some_and(|c| c == c2)
-    }
-
-    #[allow(clippy::inline_always)]
-    #[inline(always)]
-    fn next_can_be_plain_scalar(&self, in_flow: bool) -> bool {
-        let c = self.buffer.as_bytes()[0];
-        if self.buffer.len() > 1 {
-            let nc = self.buffer.as_bytes()[1];
-            match c {
-                // indicators can end a plain scalar, see 7.3.3. Plain Style
-                b':' if is_blank_or_breakz(nc as char) || (in_flow && is_flow(nc as char)) => false,
-                c if in_flow && is_flow(c as char) => false,
-                _ => true,
-            }
-        } else {
-            match c {
-                // indicators can end a plain scalar, see 7.3.3. Plain Style
-                b':' => false,
-                c if in_flow && is_flow(c as char) => false,
-                _ => true,
-            }
-        }
     }
 }
 

--- a/src/input/str.rs
+++ b/src/input/str.rs
@@ -1,7 +1,5 @@
 use crate::{
-    char_traits::{
-        is_alpha, is_blank, is_blank_or_breakz, is_break, is_breakz, is_digit, is_flow, is_z,
-    },
+    char_traits::{is_blank_or_breakz, is_flow},
     input::Input,
 };
 
@@ -139,6 +137,11 @@ impl<'a> Input for StrInput<'a> {
     }
 
     #[inline]
+    fn peek_ascii(&self) -> char {
+        self.buffer.as_bytes().first().map_or('\0', |&c| c.into())
+    }
+
+    #[inline]
     fn peek_nth(&self, n: usize) -> char {
         let mut chars = self.buffer.chars();
         for _ in 0..n {
@@ -153,11 +156,6 @@ impl<'a> Input for StrInput<'a> {
     fn look_ch(&mut self) -> char {
         self.lookahead(1);
         self.peek()
-    }
-
-    #[inline]
-    fn next_char_is(&self, c: char) -> bool {
-        self.peek() == c
     }
 
     #[inline]
@@ -241,55 +239,6 @@ impl<'a> Input for StrInput<'a> {
                 _ => true,
             }
         }
-    }
-
-    #[inline]
-    fn next_is_blank_or_break(&self) -> bool {
-        !self.buffer.is_empty()
-            && (is_blank(self.buffer.as_bytes()[0] as char)
-                || is_break(self.buffer.as_bytes()[0] as char))
-    }
-
-    #[inline]
-    fn next_is_blank_or_breakz(&self) -> bool {
-        self.buffer.is_empty()
-            || (is_blank(self.buffer.as_bytes()[0] as char)
-                || is_breakz(self.buffer.as_bytes()[0] as char))
-    }
-
-    #[inline]
-    fn next_is_blank(&self) -> bool {
-        !self.buffer.is_empty() && is_blank(self.buffer.as_bytes()[0] as char)
-    }
-
-    #[inline]
-    fn next_is_break(&self) -> bool {
-        !self.buffer.is_empty() && is_break(self.buffer.as_bytes()[0] as char)
-    }
-
-    #[inline]
-    fn next_is_breakz(&self) -> bool {
-        self.buffer.is_empty() || is_breakz(self.buffer.as_bytes()[0] as char)
-    }
-
-    #[inline]
-    fn next_is_z(&self) -> bool {
-        self.buffer.is_empty() || is_z(self.buffer.as_bytes()[0] as char)
-    }
-
-    #[inline]
-    fn next_is_flow(&self) -> bool {
-        !self.buffer.is_empty() && is_flow(self.buffer.as_bytes()[0] as char)
-    }
-
-    #[inline]
-    fn next_is_digit(&self) -> bool {
-        !self.buffer.is_empty() && is_digit(self.buffer.as_bytes()[0] as char)
-    }
-
-    #[inline]
-    fn next_is_alpha(&self) -> bool {
-        !self.buffer.is_empty() && is_alpha(self.buffer.as_bytes()[0] as char)
     }
 }
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -13,8 +13,8 @@ use std::{char, collections::VecDeque, error::Error, fmt};
 
 use crate::{
     char_traits::{
-        as_hex, is_anchor_char, is_blank, is_blank_or_breakz, is_break, is_breakz, is_flow, is_hex,
-        is_tag_char, is_uri_char,
+        as_hex, is_alpha, is_anchor_char, is_blank, is_blank_or_breakz, is_break, is_breakz,
+        is_flow, is_hex, is_tag_char, is_uri_char,
     },
     input::Input,
 };
@@ -1046,7 +1046,7 @@ impl<T: Input> Scanner<T> {
         let start_mark = self.mark;
         let mut string = String::new();
 
-        let n_chars = self.input.fetch_while_is_alpha(&mut string);
+        let n_chars = self.input.read_until(&mut string, |c| !is_alpha(c));
         self.mark.index += n_chars;
         self.mark.col += n_chars;
 
@@ -1182,7 +1182,7 @@ impl<T: Input> Scanner<T> {
         string.push(self.input.peek());
         self.skip_non_blank();
 
-        let n_chars = self.input.fetch_while_is_alpha(&mut string);
+        let n_chars = self.input.read_until(&mut string, |c| !is_alpha(c));
         self.mark.index += n_chars;
         self.mark.col += n_chars;
 

--- a/tests/span.rs
+++ b/tests/span.rs
@@ -104,6 +104,21 @@ fn test_literal() {
 }
 
 #[test]
+fn test_literal_utf8() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: |\n  你好").unwrap()),
+        [("foo", "foo"), ("你好\n", "你好"),]
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: |\n  one:你好\n  two:你好").unwrap()),
+        [
+            ("foo", "foo"),
+            ("one:你好\ntwo:你好\n", "one:你好\n  two:你好"),
+        ]
+    );
+}
+
+#[test]
 fn test_block() {
     assert_eq!(
         deref_pairs(&run_parser_and_deref_scalar_spans("foo: >\n  bar").unwrap()),
@@ -112,6 +127,21 @@ fn test_block() {
     assert_eq!(
         deref_pairs(&run_parser_and_deref_scalar_spans("foo: >\n  bar\n  more").unwrap()),
         [("foo", "foo"), ("bar more\n", "bar\n  more"),]
+    );
+}
+
+#[test]
+fn test_block_utf8() {
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: >\n  你好").unwrap()),
+        [("foo", "foo"), ("你好\n", "你好")],
+    );
+    assert_eq!(
+        deref_pairs(&run_parser_and_deref_scalar_spans("foo: >\n  one:你好\n  two:你好").unwrap()),
+        [
+            ("foo", "foo"),
+            ("one:你好 two:你好\n", "one:你好\n  two:你好")
+        ],
     );
 }
 


### PR DESCRIPTION
The idea is to make the `Input` trait a mere source of characters with lookahead capabilities, without knowing anything specific about YAML.

All functionality that is YAML specific, such as `skip_ws_to_eol` or checking for specific types of characters has been moved to `Scanner`.

As a result, all unsafe code is gone, so this PR supersedes https://github.com/saphyr-rs/saphyr-parser/pull/6.