### PR TITLE
Make `StrInput` type publicly visible

### DIFF
--- a/src/input/str.rs
+++ b/src/input/str.rs
@@ -5,6 +5,7 @@ use crate::{
     input::{Input, SkipTabs},
 };
 
+/// A parser input that uses a `&str` as source.
 #[allow(clippy::module_name_repetitions)]
 pub struct StrInput<'a> {
     /// The input str buffer.
@@ -18,6 +19,7 @@ pub struct StrInput<'a> {
 
 impl<'a> StrInput<'a> {
     /// Create a new [`StrInput`] with the given str.
+    #[must_use]
     pub fn new(input: &'a str) -> Self {
         Self {
             buffer: input,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,6 @@ mod input;
 mod parser;
 mod scanner;
 
-pub use crate::input::BufferedInput;
+pub use crate::input::{str::StrInput, BufferedInput};
 pub use crate::parser::{Event, EventReceiver, Parser, SpannedEventReceiver, Tag};
 pub use crate::scanner::{Marker, ScanError, Span, TScalarStyle};


### PR DESCRIPTION
For cases where you might need to, e.g, define a function with a `Parser<StrInput<'_>>` as argument