### PR TITLE
Better tracking for beginning and ending positions of mappings.

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2404,7 +2404,7 @@ impl<T: Input> Scanner<T> {
                 }
                 self.insert_token(
                     sk.token_number - self.tokens_parsed,
-                    Token(Span::empty(self.mark), TokenType::FlowMappingStart),
+                    Token(Span::empty(sk.mark), TokenType::FlowMappingStart),
                 );
             }
 
@@ -2413,7 +2413,7 @@ impl<T: Input> Scanner<T> {
                 sk.mark.col,
                 Some(sk.token_number),
                 TokenType::BlockMappingStart,
-                start_mark,
+                sk.mark,
             );
             self.roll_one_col_indent();
 
@@ -2422,7 +2422,7 @@ impl<T: Input> Scanner<T> {
         } else {
             if is_implicit_flow_mapping {
                 self.tokens
-                    .push_back(Token(Span::empty(self.mark), TokenType::FlowMappingStart));
+                    .push_back(Token(Span::empty(start_mark), TokenType::FlowMappingStart));
             }
             // The ':' indicator follows a complex key.
             if self.flow_level == 0 {

--- a/tests/yaml-test-suite.rs
+++ b/tests/yaml-test-suite.rs
@@ -139,6 +139,7 @@ fn parse_to_events(source: &str) -> Result<EventReporter, ScanError> {
 }
 
 #[derive(Default)]
+/// A [`SpannedEventReceiver`] checking for inconsistencies in event [`Spans`].
 pub struct EventReporter {
     pub events: Vec<String>,
     last_span: Option<(Event, Span)>,


### PR DESCRIPTION
Previously, we often used the scanner state to infer the positions of mappings. This is sometimes wrong, because the scanner has already scanned ahead by the time the mapping is parsed.

This commit adds a check to the test suite, asserting that parser event positions are all observed in order, and it fixes the scanner and parser to make the new check pass.

I'm not in love with the addition of a `Marker` to `parser::State`, but I couldn't figure out any other method to keep track of that position.