### PR TITLE
Remove bad assert.

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -2230,7 +2230,6 @@ impl<T: Input> Scanner<T> {
                             end = true;
                             break;
                         }
-                        assert!(string.len() < string.capacity());
                         string.push(self.input.peek());
                         self.skip_non_blank();
                     }


### PR DESCRIPTION
We reserve bufmaxlen bytes in the string, but then proceed to push up to bufmaxlen chars. Therefore it is possible that the string will need to reallocate. A different solution would be to reserve 4*bufmaxlen bytes. Removing the assert is probably ok, because the attempt to pre-allocate is just a performance optimization.

I ran into this while trying to port saphyr to the latest saphyr-parser. (It was triggered by the `test_check_weird_keys` test.)