### PR TITLE
Look ahead before testing for EOF.

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1709,11 +1709,11 @@ impl<T: Input> Scanner<T> {
             self.scan_block_scalar_content_line(&mut string, &mut line_buffer);
 
             // break on EOF
+            self.input.lookahead(2);
             if self.input.next_is_z() {
                 break;
             }
 
-            self.input.lookahead(2);
             self.read_break(&mut leading_break);
 
             // Eat the following indentation spaces and line breaks.

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,4 +1,4 @@
-use saphyr_parser::{Event, Parser, ScanError, TScalarStyle};
+use saphyr_parser::{BufferedInput, Event, Parser, ScanError, SpannedEventReceiver, TScalarStyle};
 
 /// Run the parser through the string.
 ///
@@ -165,4 +165,17 @@ fn test_issue1() {
             Event::StreamEnd,
         ]
     );
+}
+
+#[test]
+fn test_pr12() {
+    struct Recv {}
+    impl SpannedEventReceiver for Recv {
+        fn on_event(&mut self, ev: Event, span: saphyr_parser::Span) {}
+    }
+    let s = "---\n- |\n  a";
+    let input = BufferedInput::new(s.chars());
+    let mut parser = Parser::new(input);
+    let mut recv = Recv {};
+    parser.load(&mut recv, true);
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,12 +1,24 @@
-use saphyr_parser::{BufferedInput, Event, Parser, ScanError, SpannedEventReceiver, TScalarStyle};
+use saphyr_parser::{BufferedInput, Event, Parser, ScanError, TScalarStyle};
 
 /// Run the parser through the string.
 ///
 /// # Returns
-/// This functions returns the events if parsing succeeds, the error the parser returned otherwise.
+/// This function returns the events if parsing succeeds, the error the parser returned otherwise.
 fn run_parser(input: &str) -> Result<Vec<Event>, ScanError> {
     let mut events = vec![];
     for x in Parser::new_from_str(input) {
+        events.push(x?.0);
+    }
+    Ok(events)
+}
+
+/// Run the parser through the string, using a `BufferedInput`
+///
+/// # Returns
+/// This function returns the events if parsing succeeds, the error the parser returned otherwise.
+fn run_parser_buffered(input: &str) -> Result<Vec<Event>, ScanError> {
+    let mut events = vec![];
+    for x in Parser::new(BufferedInput::new(input.chars())) {
         events.push(x?.0);
     }
     Ok(events)
@@ -169,13 +181,16 @@ fn test_issue1() {
 
 #[test]
 fn test_pr12() {
-    struct Recv {}
-    impl SpannedEventReceiver for Recv {
-        fn on_event(&mut self, _ev: Event, _span: saphyr_parser::Span) {}
-    }
-    let s = "---\n- |\n  a";
-    let input = BufferedInput::new(s.chars());
-    let mut parser = Parser::new(input);
-    let mut recv = Recv {};
-    parser.load(&mut recv, true).unwrap();
+    assert_eq!(
+        run_parser_buffered("---\n- |\n  a").unwrap(),
+        [
+            Event::StreamStart,
+            Event::DocumentStart(true),
+            Event::SequenceStart(0, None),
+            Event::Scalar("a\n".to_string(), TScalarStyle::Literal, 0, None),
+            Event::SequenceEnd,
+            Event::DocumentEnd,
+            Event::StreamEnd,
+        ]
+    );
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -171,11 +171,11 @@ fn test_issue1() {
 fn test_pr12() {
     struct Recv {}
     impl SpannedEventReceiver for Recv {
-        fn on_event(&mut self, ev: Event, span: saphyr_parser::Span) {}
+        fn on_event(&mut self, _ev: Event, _span: saphyr_parser::Span) {}
     }
     let s = "---\n- |\n  a";
     let input = BufferedInput::new(s.chars());
     let mut parser = Parser::new(input);
     let mut recv = Recv {};
-    parser.load(&mut recv, true);
+    parser.load(&mut recv, true).unwrap();
 }

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -67,3 +67,19 @@ macro_rules! assert_next {
 // auto generated from handler_spec_test.cpp
 include!("specexamples.rs.inc");
 include!("spec_test.rs.inc");
+
+mod with_buffered_input {
+    use super::{Parser, TestEvent, YamlChecker};
+
+    fn str_to_test_events(docs: &str) -> Vec<TestEvent> {
+        use saphyr_parser::BufferedInput;
+
+        let mut p = YamlChecker { evs: Vec::new() };
+        let input = BufferedInput::new(docs.chars());
+        let mut parser = Parser::new(input);
+        parser.load(&mut p, true).unwrap();
+        p.evs
+    }
+    include!("specexamples.rs.inc");
+    include!("spec_test.rs.inc");
+}


### PR DESCRIPTION
This fixes panics in saphyr's test_multiline_trailing_newline and test_multiline_leading_newline tests, in which `self.input.next_is_z` would be called on an empty buffer and panic in `peek`